### PR TITLE
Add pre-commit validation hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,44 @@
 ci:
+  autoupdate_schedule: monthly
   autofix_prs: false
 
-exclude: ^.*/__snapshots__/.*\.ambr$
+exclude: (^|/)__snapshots__/
 
 repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-vcs-permalinks
       - id: debug-statements
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+        types:
+          - text
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+        description: Forces to replace line ending by the UNIX 'lf' character.
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-toml
       - id: check-added-large-files
+        args:
+          - --maxkb=10000
         exclude: pixi.lock
+      - id: no-commit-to-branch
+        args:
+          - --branch
+          - main
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.34.0
     hooks:


### PR DESCRIPTION
## What problem do you want to solve?

Part of #31.

This PR expands the pre-commit configuration with low-risk validation and safety hooks, while avoiding formatter and notebook-output hooks that would create larger mechanical diffs.

## What changed?

- Added monthly pre-commit autoupdate scheduling.
- Broadened the snapshot exclusion to skip all `__snapshots__/` directories.
- Added pre-commit meta checks:
  - `check-hooks-apply`
  - `check-useless-excludes`
- Added validation/safety hooks:
  - `check-ast`
  - `check-case-conflict`
  - `check-docstring-first`
  - `check-merge-conflict`
  - `check-vcs-permalinks`
  - `fix-byte-order-marker`
  - `mixed-line-ending`
  - `no-commit-to-branch`
- Configured `check-added-large-files` with `--maxkb=10000`.

## Known follow-ups

This PR intentionally does not add the more invasive hooks yet:

- `pyproject-fmt`
- `yamlfix`
- `yamllint`
- `mdformat`
- `nbstripout`

Those should be handled separately because they may create broad formatting or notebook diffs.

## Validation

- All newly added hooks were run individually and passed.
- Commit hooks passed.
- Full `pre-commit run --all-files` still exposes unrelated existing Ruff/mypy issues and would modify many files, so those changes were not included in this PR.